### PR TITLE
2 error in appjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ services:
 # Swagger-UI
 
 The swagger-ui can be accessed on the /doc endpoint
-so e.g. open [http://127.0.0.1:8080/doc](http://127.0.0.1:9090/doc) in the browser and the swagger-ui will open
+so e.g. open [http://127.0.0.1:9090/doc](http://127.0.0.1:9090/doc) in the browser and the swagger-ui will open
 
 # Swagger-Configuration file
 
 The swagger-/openapi-configuration file can be retrieved on the /help endpoint
-so e.g. open [http://127.0.0.1:8080/help](http://127.0.0.1:9090/help) in the browser and the swagger-configuration file will load
+so e.g. open [http://127.0.0.1:9090/help](http://127.0.0.1:9090/help) in the browser and the swagger-configuration file will load
 
 # BUG IN ZEEP
 

--- a/nodejs/app.js
+++ b/nodejs/app.js
@@ -29,7 +29,7 @@ app.post('/api/:service/:port/:action', function (req, res) {
       });
       //client.on('request', function(envelope) {
       //  console.error(util.inspect(envelope, {showHidden: false, depth: null}));
-      });
+      //});
       //client.on('response', function (responseBody, incomingMessage) {
       //  console.error(responseBody);
       //  console.error(incomingMessage);

--- a/nodejs/app.js
+++ b/nodejs/app.js
@@ -12,7 +12,7 @@ require('http').IncomingMessage = IncomingMessage
 const express = require('express');
 const bodyParser = require('body-parser');
 const soap = require('strong-soap').soap;
-const util = require('util');
+//const util = require('util');
 
 process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = 0;
 const url = process.env['SOAP_URL'];


### PR DESCRIPTION
+ Edited the README.md to reflect the port changes made to the Hyperlinks in the rendered page (from 8080 to 9090)
+ Fixed an issue in app.js that stopped the container from being started successfully (extra pair of brackets in function app.post(..))
+ Commented out a constant that is not used in production and only needed for debugging 

Closes #2 